### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,5 +40,5 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
-          name: bottles
-          path: '*.bottle.*'
+          name: bottles-${{ matrix.os }}
+          path: "*.bottle.*"

--- a/Formula/autify-cli.rb
+++ b/Formula/autify-cli.rb
@@ -3,7 +3,7 @@
 # Edit https://github.com/autifyhq/autify-cli/blob/main/autify-cli.rb instead.
 
 class AutifyCli < Formula
-  desc "Autify Command Line Interface (CLI)"
+  desc "Autify Command-Line Interface (CLI)"
   homepage "https://github.com/autifyhq/autify-cli"
   url "https://github.com/autifyhq/autify-cli", using: :git, revision: "b2241b2"
   version "0.45.0"
@@ -25,7 +25,7 @@ class AutifyCli < Formula
 
   def taball_url
     package = JSON.parse(File.read("./package.json"), symbolize_names: true)
-    raise "Version mismatch: #{package[:version]}" unless package[:version] == version
+    raise "Version mismatch: #{package[:version]}" if package[:version] != version
 
     bucket = package.dig(:oclif, :update, :s3, :bucket)
     folder = package.dig(:oclif, :update, :s3, :folder)


### PR DESCRIPTION
1. Rubocop related lint errors:

https://github.com/autifyhq/homebrew-tap/actions/runs/9203403972/job/25314872642

```
  /opt/homebrew/Library/Taps/autifyhq/homebrew-tap/Formula/autify-cli.rb:6:16: C: [Correctable] FormulaAudit/Desc: Description should use "Command-line" instead of "Command Line".
    desc "Autify Command Line Interface (CLI)"
                 ^^^^^^^^^^^^
  /opt/homebrew/Library/Taps/autifyhq/homebrew-tap/Formula/autify-cli.rb:28:5: C: [Correctable] Style/InvertibleUnlessCondition: Prefer if package[:version] != version over unless package[:version] == version.
      raise "Version mismatch: #{package[:version]}" unless package[:version] == version
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

2. Artifact name collision

https://github.com/autifyhq/homebrew-tap/actions/runs/9203486797/job/25315104421?pr=1

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```